### PR TITLE
Add eventemitter3 dependency to unbreak http-proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "node": "0.10.x"
   },
   "dependencies": {
-    "http-proxy": "1.6.1"
+    "http-proxy": "1.6.1",
+    "eventemitter3": "0.1.6"
   }
 }


### PR DESCRIPTION
The version of eventemitter3 installed when no particular version is specified prevents pepto from running. 
