### PR TITLE
Upgrade node and http-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "pepto-symbol",
   "version": "0.0.1",
   "engines": {
-    "node": "0.10.x"
+    "node": "6.9.1"
   },
   "dependencies": {
-    "http-proxy": "1.6.1"
+    "http-proxy": "1.15.2"
+  },
+  "scripts": {
+    "start": "node pepto-symbol.js"
   }
 }


### PR DESCRIPTION
- Upgrade node to latest LTS, 6.9.1
- Upgrade http-proxy to latest release, 1.15.2
- Add `npm start` script
- Ignore `npm-debug.log`