### PR TITLE
Add optional path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ http://pepto-symbol.gadgetron.com/awesome/symbols
 
 That's it!
 
+### Path Prefix
+
+You can add an optional `PATH_PREFIX` environment variables for shorter URLs.
+This prefix will be prepended to all requests paths to the S3 bucket.
+
+```shell
+heroku config:add PATH_PREFIX=/awesome/symbols
+```
+
+Now the symbol server URL can be `http://pepto-symbol.gadgetron.com`.
+
 ### Running locally
 
 To run Pepto Symbol locally on port 5000:

--- a/pepto-symbol.js
+++ b/pepto-symbol.js
@@ -3,6 +3,7 @@ var httpProxy = require('http-proxy');
 
 const TARGET_HOST = process.env.S3_BUCKET + '.s3.amazonaws.com';
 const TARGET = 'http://' + TARGET_HOST;
+const PATH_PREFIX = process.env.PATH_PREFIX || '';
 
 // Create a proxy server with custom application logic.
 var proxy = httpProxy.createProxyServer({});
@@ -31,7 +32,7 @@ proxy.on('proxyReq', function(proxyReq, request, response, options) {
 // to S3 with all-lowercase keys, and we lowercase all requests we receive to
 // match.
 proxy.on('proxyReq', function(proxyReq, request, response, options) {
-  proxyReq.path = proxyReq.path.toLowerCase();
+  proxyReq.path = PATH_PREFIX + proxyReq.path.toLowerCase();
 });
 
 http.createServer(function(request, response) {


### PR DESCRIPTION
This allows a prefix to be prepended to all generated S3 URLs allowing shorter URLs.